### PR TITLE
Update advanced-configuration.rst - ajout partie import POI et suppression import zones sensibles

### DIFF
--- a/docs/install/advanced-configuration.rst
+++ b/docs/install/advanced-configuration.rst
@@ -736,6 +736,21 @@ POI
 
         500
 
+Import from shapefile
+'''''''''''''''''''''''
+
+In user interface, in the top-right menu, go to Imports and choose "Données à importer depuis un fichier local"
+then click on "Import POI ".
+
+.. note::
+  The file must be a zip containing all the shapefile extensions (.shp, .shx, .prj, .dbf, .cpg)
+
+.. figure:: ../images/advanced-configuration/import_poi_shapefile.png
+   :alt: Import shapefile in user interface
+   :align: center
+
+   Import shapefile in user interface
+
 Diving
 ~~~~~~
 
@@ -868,22 +883,6 @@ On command line, run
 .. code-block:: bash
 
     sudo geotrek import geotrek.sensitivity.parsers.BiodivParser
-
-
-Import from shapefile
-'''''''''''''''''''''''
-
-In user interface, in the top-right menu, go to Imports and choose "Shapefile zone sensible espèce"
-or "Shapefile zone sensible réglementaire".
-
-.. note::
-  The file must be a zip containing all the shapefile extensions (.shp, .shx, .prj, .dbf, .cpg)
-
-.. figure:: ../images/advanced-configuration/import_shapefile.png
-   :alt: Import shapefile in user interface
-   :align: center
-
-   Import shapefile in user interface
 
 
 On command line, run:


### PR DESCRIPTION


## Description

Ajout d'une image et d'une description plus détaillée pour l'import de poi depuis l'interface de Geotrek-admin et suppression de la partie pour l'import des zones sensibles qui n'est plus disponible.

## Related Issue

Par contre, je suis bien conscient que ça ne détaille pas tout, il manque les champs de la table trekking_poi qui sont obligatoire à l'import. Je voulais les détailler pour préciser à quoi doit ressembler la table attributaire sous QGIS, mais j'ai vu que la table public.trekking_poi a une clé étrangère topo_object_id provenant de la table public.core_topology. 

Je ne suis pas sûr de bien comprendre le but de cette table, et encore moins à même de savoir si un utilisateur lambda pourrait obtenir les id de son côté pour remplir ce champ.





